### PR TITLE
fix: fix missing RefAttributes

### DIFF
--- a/packages/collapse/src/interface.tsx
+++ b/packages/collapse/src/interface.tsx
@@ -44,7 +44,7 @@ export interface CollapseContextProps {
 }
 
 export interface CollapseComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<CollapseProps>> {
+  extends ForwardRefExoticComponent<PropsWithChildren<CollapseProps> & RefAttributes<HTMLDivElement>> {
   Item: ForwardRefExoticComponent<
     CollapseItemProps & RefAttributes<HTMLDivElement>
   >

--- a/packages/menu/src/interface.tsx
+++ b/packages/menu/src/interface.tsx
@@ -4,6 +4,7 @@ import {
   MouseEvent,
   PropsWithChildren,
   ReactNode,
+  RefAttributes
 } from "react"
 import { TriggerProps } from "@illa-design/trigger"
 import { SerializedStyles } from "@emotion/serialize"
@@ -75,7 +76,8 @@ export interface OverflowWrapperProps {
 }
 
 export interface MenuComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<MenuProps>> {
+  extends
+  ForwardRefExoticComponent<PropsWithChildren<MenuProps> & RefAttributes<HTMLDivElement>> {
   Item: ForwardRefExoticComponent<ItemProps>
   ItemGroup: ForwardRefExoticComponent<PropsWithChildren<ItemGroupProps>>
   SubMenu: ForwardRefExoticComponent<PropsWithChildren<SubMenuProps>>

--- a/packages/message/src/interface.tsx
+++ b/packages/message/src/interface.tsx
@@ -7,6 +7,7 @@ import {
   ForwardRefExoticComponent,
   HTMLAttributes,
   PropsWithChildren,
+  RefAttributes
 } from "react"
 
 export interface MessageSet {
@@ -22,7 +23,7 @@ export interface MessageProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export interface MessageComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<MessageProps>> {
+  extends ForwardRefExoticComponent<PropsWithChildren<MessageProps> & RefAttributes<HTMLDivElement>> {
   info: (config: NoticeProps | string) => void
   success: (config: NoticeProps | string) => void
   warning: (config: NoticeProps | string) => void

--- a/packages/modal/src/interface.tsx
+++ b/packages/modal/src/interface.tsx
@@ -5,6 +5,7 @@ import {
   MouseEvent,
   ReactNode,
   ReactElement,
+  RefAttributes
 } from "react"
 import { ButtonProps } from "@illa-design/button"
 import { AlertType as ModalType } from "@illa-design/alert"
@@ -64,7 +65,7 @@ export interface ConfirmProps extends ModalProps {
 }
 
 export interface ModalComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<ModalProps>> {
+  extends ForwardRefExoticComponent<PropsWithChildren<ModalProps> & RefAttributes<HTMLDivElement>> {
   confirm: (props: ConfirmProps) => ModalReturnProps
   info: (props: ConfirmProps) => ModalReturnProps
   success: (props: ConfirmProps) => ModalReturnProps

--- a/packages/notification/src/interface.tsx
+++ b/packages/notification/src/interface.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   ForwardRefExoticComponent,
   PropsWithChildren,
+  RefAttributes
 } from "react"
 import { AlertType } from "@illa-design/alert"
 
@@ -34,7 +35,7 @@ export interface NotificationProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export interface NotificationComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<NotificationProps>> {
+  extends ForwardRefExoticComponent<PropsWithChildren<NotificationProps> & RefAttributes<HTMLDivElement>> {
   info: (config: NoticeProps) => void
   success: (config: NoticeProps) => void
   warning: (config: NoticeProps) => void


### PR DESCRIPTION
## 📝 Description

Fix missing ref attribute

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

When using `ForwardRefExoticComponent` to define type, there is no `ref` attribute by default.

A `RefAttributes` should be added to avoid saying that `ref` is not defined on the type when using the component.