### PR TITLE
fix: divider display

### DIFF
--- a/packages/divider/src/style.tsx
+++ b/packages/divider/src/style.tsx
@@ -6,7 +6,6 @@ export function applyDividerContainerHorizontal(
   variant: DividerVariant,
 ): SerializedStyles {
   return css`
-    display: inline-flex;
     vertical-align: middle;
     border-color: ${globalColor(`--${illaPrefix}-grayBlue-08`)};
     border-style: ${variant};

--- a/packages/divider/tests/__snapshots__/divider.test.tsx.snap
+++ b/packages/divider/tests/__snapshots__/divider.test.tsx.snap
@@ -3,10 +3,6 @@
 exports[`Divider renders default 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   vertical-align: middle;
   border-color: #e5e6eb;
   border-style: solid;
@@ -23,10 +19,6 @@ exports[`Divider renders default 1`] = `
 exports[`Divider renders horizontal 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   vertical-align: middle;
   border-color: #e5e6eb;
   border-style: solid;

--- a/packages/list/tests/__snapshots__/list.test.tsx.snap
+++ b/packages/list/tests/__snapshots__/list.test.tsx.snap
@@ -123,7 +123,6 @@ exports[`List renders without border and split 1`] = `
 }
 
 .emotion-11 {
-  display: inline-flex;
   vertical-align: middle;
   border-color: #e5e6eb;
   border-style: solid;


### PR DESCRIPTION
## 📝 Description

when use `<Divider />`,it has error  display

```tsx
// example
<div style={{width:"200px"}} id="wrapper">
  <Divider />
  <div style={{height:"20px"}}>Test</div>
  <Divider />
</div>
```
the wrapper's height will much larger than 20px;

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

