### PR TITLE
fix: omit `triggerProps` of `select-view`

### DIFF
--- a/packages/select/src/interface.tsx
+++ b/packages/select/src/interface.tsx
@@ -130,7 +130,7 @@ export interface SelectProps
 export interface SelectViewProps
   extends Omit<
     SelectProps,
-    "options" | "filterOption" | "onChange" | "onClear"
+    "options" | "filterOption" | "onChange" | "onClear" | "triggerProps"
   > {
   value?: any
   defaultValue?: any

--- a/packages/select/src/select-view.tsx
+++ b/packages/select/src/select-view.tsx
@@ -1,11 +1,4 @@
-import {
-  forwardRef,
-  SyntheticEvent,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from "react"
+import { forwardRef, SyntheticEvent, useEffect, useRef, useState } from "react"
 import { InputElement, InputElementProps } from "@illa-design/input"
 import { isNumber, isObject, omit } from "@illa-design/system"
 import {

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -7,7 +7,7 @@ import {
   ReactText,
   SyntheticEvent,
 } from "react"
-import { useMergeValue, isArray, isObject } from "@illa-design/system"
+import { useMergeValue, isArray, isObject, omit } from "@illa-design/system"
 import { Trigger } from "@illa-design/trigger"
 import { SelectView } from "./select-view"
 import {
@@ -373,7 +373,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
       {...triggerProps}
     >
       <SelectView
-        {...props}
+        {...omit(props, ["triggerProps"])}
         {...selectViewEventHandlers}
         ref={ref}
         value={currentValue}


### PR DESCRIPTION
## 📝 Description

Omit `triggerProps` of `select-view` component

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol